### PR TITLE
Fix ReDoS issue

### DIFF
--- a/src/skip-regex.js
+++ b/src/skip-regex.js
@@ -30,7 +30,7 @@ export default (function () {
 
   // Matches literal regex from the start of the buffer.
   // The buffer to search must not include line-endings.
-  const R_JS_REGEX = /^\/(?=[^*/])[^[/\\]*(?:(?:\\.|\[(?:\\.|[^\]\\]*)*\])[^[\\/]*)*?\/[gimuys]*/
+  const R_JS_REGEX = /^\/(?=[^*/])[^[/\\]*(?:(?:\\.|\[(?:\\.|[^\]\\])*\])[^[\\/]*)*?\/[gimuys]*/
 
   // Valid characters for JavaScript variable names and literal numbers.
   const R_JS_VCHAR = /[$\w]/


### PR DESCRIPTION
Hello,

There is a Regex Denial of Service (ReDoS) that this PR fixes.

`(?:\\.|[^\]\\]*)*` can be simplified to `(?:\\.|[^\]\\])*` which resolves the issue.

You can check the original and updated regex using this [ReDoS checker](https://devina.io/redos-checker):

original: `/^\/(?=[^*/])[^[/\\]*(?:(?:\\.|\[(?:\\.|[^\]\\]*)*\])[^[\\/]*)*?\/[gimuys]*/`
fixed: `/^\/(?=[^*/])[^[/\\]*(?:(?:\\.|\[(?:\\.|[^\]\\])*\])[^[\\/]*)*?\/[gimuys]*/`

Example that causes the problem:

`/^\/(?=[^*/])[^[/\\]*(?:(?:\\.|\[(?:\\.|[^\]\\]*)*\])[^[\\/]*)*?\/[gimuys]*/.test('/[[/g][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][gg][g')`

Thank you for your consideration.